### PR TITLE
Enable anndata to seurat conversion

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -247,7 +247,7 @@ anndata2seurat <- function(inFile, outFile = NULL, main_layer = 'counts', assay 
         Seurat::Idents(srt) <- project_name
 
         srt@meta.data <- obs_df
-        embed_names <- unlist(reticulate::py_to_r(ad$obsm$keys()))
+        embed_names <- unlist(reticulate::py_to_r(ad$obsm_keys()))
         if (length(embed_names) > 0) {
             embeddings <- sapply(embed_names, function(x) reticulate::py_to_r(ad$obsm[x]), simplify = FALSE, USE.NAMES = TRUE)
             names(embeddings) <- embed_names

--- a/R/methods.R
+++ b/R/methods.R
@@ -1,5 +1,5 @@
 convertFormat <- function(
-    obj, from = c('seurat', 'sce', 'loom'), to = c('anndata', 'loom', 'sce'), outFile = NULL,
+    obj, from = c('anndata', 'seurat', 'sce', 'loom'), to = c('anndata', 'loom', 'sce', 'seurat'), outFile = NULL,
     main_layer = NULL, ...
 ) {
     from <- match.arg(from)


### PR DESCRIPTION
Add anndata and seurat to permitted to/from strings.

Fix return type of obsm.keys() so it returns a list of strings instead of a KeysView object.