### PR TITLE
AnnData to Seurat: Add functionality to store X in data and raw.X in counts

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -232,6 +232,10 @@ anndata2seurat <- function(inFile, outFile = NULL, main_layer = 'counts', assay 
             assays <- list(Seurat::CreateAssayObject(data = raw_X))
             assays[[1]] <- Seurat::SetAssayData(assays[[1]], slot = 'scale.data', new.data = X)
             message('X -> scale.data; raw.X -> data')
+        } else if (main_layer == 'data' && !is.null(raw_X)) {
+            assays <- list(Seurat::CreateAssayObject(counts = raw_X))
+            assays[[1]] <- Seurat::SetAssayData(assays[[1]], slot = 'data', new.data = X)
+            message('X -> data; raw.X -> counts')
         } else if (main_layer == 'counts') {
             assays <- list(Seurat::CreateAssayObject(counts = X))
             message('X -> counts')


### PR DESCRIPTION
`sceasy::convertFormat(h5ad_path, from="anndata", to="seurat", outFile =seurat_path, main_layer = "data")`

If there was a raw layer in the source AnnData, the command above would not transfer that to the output seurat object (when `main_layer=data`)

Now, when executing that command:

- The matrix in the main layer of the AnnData is stored in `seurat@assays$RNA@data`
- And the matrix in the raw layer is stored in `seurat@assays$RNA@counts`