### PR TITLE
Fix dimensions of raw layer when needed (anndata2seurat)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,10 @@ before_install:
       conda config --add channels defaults;
       conda config --add channels bioconda;
       conda config --add channels conda-forge;
-      conda create -q -y -n $TEST_ENV r-seurat=3.1.0 bioconductor-singlecellexperiment bioconductor-loomexperiment=1.2.0 r-reticulate r-devtools scipy=1.2.1 anndata=0.6.19 loompy=2 h5py=2.9.0;
+      conda create -q -y -n $TEST_ENV r-seurat=3.1.0 r-reticulate r-devtools scipy=1.2.1 anndata=0.6.19 loompy=2 h5py=2.9.0;
+      source activate "$TEST_ENV"
+      Rscript -e 'install.packages("BiocManager"); BiocManager::install("SingleCellExperiment"); BiocManager::install("loomexperiment")'
+      conda deactivate
     fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,9 @@ before_install:
       conda config --add channels bioconda;
       conda config --add channels conda-forge;
       conda create -q -y -n $TEST_ENV r-seurat=3.1.0 r-reticulate r-devtools scipy=1.2.1 anndata=0.6.19 loompy=2 h5py=2.9.0;
-      condat activate "$TEST_ENV"
-      Rscript -e "install.packages('BiocManager'); BiocManager::install('SingleCellExperiment'); BiocManager::install(;LoomExperiment')"
-      conda deactivate
+      source activate "$TEST_ENV";
+      Rscript -e "install.packages('BiocManager'); BiocManager::install('SingleCellExperiment'); BiocManager::install(;LoomExperiment')";
+      conda deactivate;
     fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
       conda config --add channels conda-forge;
       conda create -q -y -n $TEST_ENV r-seurat=3.1.0 r-reticulate r-devtools scipy=1.2.1 anndata=0.6.19 loompy=2 h5py=2.9.0;
       source activate "$TEST_ENV"
-      Rscript -e 'install.packages("BiocManager"); BiocManager::install("SingleCellExperiment"); BiocManager::install("loomexperiment")'
+      Rscript -e 'install.packages("BiocManager"); BiocManager::install("SingleCellExperiment"); BiocManager::install("LoomExperiment")'
       conda deactivate
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,8 @@ before_install:
       conda config --add channels bioconda;
       conda config --add channels conda-forge;
       conda create -q -y -n $TEST_ENV r-seurat=3.1.0 r-reticulate r-devtools scipy=1.2.1 anndata=0.6.19 loompy=2 h5py=2.9.0;
-      source activate "$TEST_ENV"
-      Rscript -e 'install.packages("BiocManager"); BiocManager::install("SingleCellExperiment"); BiocManager::install("LoomExperiment")'
+      condat activate "$TEST_ENV"
+      Rscript -e "install.packages('BiocManager'); BiocManager::install('SingleCellExperiment'); BiocManager::install(;LoomExperiment')"
       conda deactivate
     fi
 

--- a/R/functions.R
+++ b/R/functions.R
@@ -229,6 +229,12 @@ anndata2seurat <- function(inFile, outFile = NULL, main_layer = 'counts', assay 
             raw_var_df <- NULL
             raw_X <- NULL
         }
+        
+        if(!is.null(raw_X) & nrow(X) != nrow(raw_X) & main_layer != 'counts') {
+            message("Raw layer was found with different number of genes than main layer, resizing X and raw.X to match dimensions")
+            raw_X <- raw_X[rownames(raw_X) %in% rownames(X), , drop=F ]
+            X <- X[rownames(raw_X), , drop=F]
+        }
 
         if (main_layer == 'scale.data' && !is.null(raw_X)) {
             assays <- list(Seurat::CreateAssayObject(data = raw_X))

--- a/R/functions.R
+++ b/R/functions.R
@@ -232,6 +232,10 @@ anndata2seurat <- function(inFile, outFile = NULL, main_layer = 'counts', assay 
             assays <- list(Seurat::CreateAssayObject(data = raw_X))
             assays[[1]] <- Seurat::SetAssayData(assays[[1]], slot = 'scale.data', new.data = X)
             message('X -> scale.data; raw.X -> data')
+        } else if (main_layer == 'data' && !is.null(raw_X)) {
+            assays <- list(Seurat::CreateAssayObject(counts = raw_X))
+            assays[[1]] <- Seurat::SetAssayData(assays[[1]], slot = 'data', new.data = X)
+            message('X -> data; raw.X -> counts')
         } else if (main_layer == 'counts') {
             assays <- list(Seurat::CreateAssayObject(counts = X))
             message('X -> counts')

--- a/R/functions.R
+++ b/R/functions.R
@@ -64,6 +64,7 @@ seurat2anndata <- function(
 sce2anndata <- function(
     obj, outFile = NULL, main_layer = 'counts', transfer_layers = NULL, drop_single_values = TRUE
 ) {
+    library('SingleCellExperiment')
     if (exists('updateObject', where='package:SingleCellExperiment', mode='function')) {
         obj <- SingleCellExperiment::updateObject(obj)
     }
@@ -150,6 +151,7 @@ seurat2sce <- function(obj, outFile = NULL, main_layer=NULL, assay='RNA', ...) {
 }
 
 sce2loom <- function(obj, outFile, main_layer = NULL, drop_single_values = TRUE, ...) {
+    library('SingleCellExperiment')
     if (exists('updateObject', where='package:SingleCellExperiment', mode='function')) {
         obj <- SingleCellExperiment::updateObject(obj)
     }


### PR DESCRIPTION
This is to address @nh3 comment [here] (https://github.com/cellgeni/sceasy/pull/25#issuecomment-783803808)

When raw.X and X have different number of genes and `main_layer=['data'|'scaled_data']`, it resizes them to have the same number of genes in anndata2seurat.