### PR TITLE
anndata to eurat Fix dimensions of raw layer when needed ()

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -227,6 +227,12 @@ anndata2seurat <- function(inFile, outFile = NULL, main_layer = 'counts', assay 
             raw_var_df <- NULL
             raw_X <- NULL
         }
+        
+        if(!is.null(raw_X) & nrow(X) != nrow(raw_X) & main_layer != 'counts') {
+            message("Raw layer was found with different number of genes than main layer, resizing X and raw.X to match dimensions")
+            raw_X <- raw_X[rownames(raw_X) %in% rownames(X), , drop=F ]
+            X <- X[rownames(raw_X), , drop=F]
+        }
 
         if (main_layer == 'scale.data' && !is.null(raw_X)) {
             assays <- list(Seurat::CreateAssayObject(data = raw_X))

--- a/R/functions.R
+++ b/R/functions.R
@@ -232,6 +232,10 @@ anndata2seurat <- function(inFile, outFile = NULL, main_layer = 'counts', assay 
             assays <- list(Seurat::CreateAssayObject(data = raw_X))
             assays[[1]] <- Seurat::SetAssayData(assays[[1]], slot = 'scale.data', new.data = X)
             message('X -> scale.data; raw.X -> data')
+        } else if (main_layer == 'data' && !is.null(raw_X)) {
+            assays <- list(Seurat::CreateAssayObject(counts = raw_X))
+            assays[[1]] <- Seurat::SetAssayData(assays[[1]], slot = 'data', new.data = X)
+            message('X -> data; raw.X -> counts')
         } else if (main_layer == 'counts') {
             assays <- list(Seurat::CreateAssayObject(counts = X))
             message('X -> counts')


### PR DESCRIPTION
This is to address @nh3 https://github.com/cellgeni/sceasy/pull/25#issuecomment-783803808

When raw.X and X have different number of genes and `main_layer=['data'|'scaled_data']`, it resizes them to have the same number of genes in anndata2seurat.