### PR TITLE
Fix anndata2seurat() for Seurat v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
       conda config --add channels bioconda;
       conda config --add channels conda-forge;
       conda create -q -y -n $TEST_ENV r-reticulate anndata loompy;
-      conda install -q -y -n $TEST_ENV bioconductor-singlecellexperiment bioconductor-loomexperiment "r-seurat=3" "r-spatstat=1.64_1" r-monocle3;
+      conda install -q -y -n $TEST_ENV bioconductor-singlecellexperiment bioconductor-loomexperiment r-seurat=4 r-monocle3;
     fi;
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
       conda config --add channels defaults;
       conda config --add channels bioconda;
       conda config --add channels conda-forge;
-      conda create -q -y -n $TEST_ENV r-reticulate r-remotes anndata loompy;
+      conda create -q -y -n $TEST_ENV r-reticulate anndata loompy;
       conda install -q -y -n $TEST_ENV bioconductor-singlecellexperiment bioconductor-loomexperiment r-seurat=4 "r-deldir>=1.0.2" r-monocle3;
     fi;
 
@@ -43,12 +43,11 @@ install:
 
 before_script:
   - mkdir -p data
+  - wget http://seurat.nygenome.org/src/contrib/pbmc3k.SeuratData_3.1.4.tar.gz
+  - tar xzvf pbmc3k.SeuratData_3.1.4.tar.gz
 
 script:
-  - Rscript -e 'remotes::install_github("satijalab/seurat-data", dependencies=F)'
-            -e 'library(SeuratData)'
-            -e 'InstallData("pbmc3k")'
-            -e 'data("pbmc3k")'
+  - Rscript -e 'load("pbmc3k.SeuratData/data/pbmc3k.rda")'
             -e 'library(sceasy)'
             -e 'srt <- pbmc3k'
             -e 'dir.create("data")'

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
       conda config --add channels defaults;
       conda config --add channels bioconda;
       conda config --add channels conda-forge;
-      conda create -q -y -n $TEST_ENV r-reticulate anndata loompy;
+      conda create -q -y -n $TEST_ENV r-reticulate r-remotes anndata loompy;
       conda install -q -y -n $TEST_ENV bioconductor-singlecellexperiment bioconductor-loomexperiment r-seurat=4 "r-deldir>=1.0.2" r-monocle3;
     fi;
 
@@ -45,16 +45,20 @@ before_script:
   - mkdir -p data
 
 script:
-  - Rscript -e 'library(sceasy)'
-            -e 'srt <- Seurat::pbmc_small'
+  - Rscript -e 'remotes::install_github("satijalab/seurat-data", dependencies=F)'
+            -e 'library(SeuratData)'
+            -e 'InstallData("pbmc3k")'
+            -e 'data("pbmc3k")'
+            -e 'library(sceasy)'
+            -e 'srt <- pbmc3k'
             -e 'dir.create("data")'
-            -e 'sceasy::convertFormat(srt, from="seurat", to="anndata", outFile="data/pbmc3k-small_seurat3_anndata.h5ad")'
-            -e 'sce <- sceasy::convertFormat(srt, from="seurat", to="sce", outFile="data/pbmc3k-small_seurat3_sce.rds")'
-            -e 'sceasy::convertFormat(sce, from="sce", to="anndata", outFile="data/pbmc3k-small_seurat3_sce_anndata.h5ad")'
-            -e 'sceasy::convertFormat("data/pbmc3k-small_seurat3_anndata.h5ad", from="anndata", to="cds", outFile="data/pbmc3k-small_seurat3_anndata_cds.rds")'
-            -e 'sceasy::convertFormat(sce, from="sce", to="loom", outFile="data/pbmc3k-small_seurat3_sce_loom.loom")'
-            -e 'sceasy::convertFormat("data/pbmc3k-small_seurat3_sce_loom.loom", from="loom", to="anndata", outFile="data/pbmc3k-small_seurat3_sce_loom_anndata.h5ad")'
-            -e 'sceasy::convertFormat("data/pbmc3k-small_seurat3_sce_loom.loom", from="loom", to="sce", outFile="data/pbmc3k-small_seurat3_sce_loom_sce.rds", main_layer_name="scaled")'
+            -e 'sceasy::convertFormat(srt, from="seurat", to="anndata", outFile="data/pbmc3k_seurat_anndata.h5ad")'
+            -e 'sce <- sceasy::convertFormat(srt, from="seurat", to="sce", outFile="data/pbmc3k_seurat_sce.rds")'
+            -e 'sceasy::convertFormat(sce, from="sce", to="anndata", outFile="data/pbmc3k_seurat_sce_anndata.h5ad")'
+            -e 'sceasy::convertFormat("data/pbmc3k_seurat_anndata.h5ad", from="anndata", to="cds", outFile="data/pbmc3k_seurat_anndata_cds.rds")'
+            -e 'sceasy::convertFormat(sce, from="sce", to="loom", outFile="data/pbmc3k_seurat_sce_loom.loom")'
+            -e 'sceasy::convertFormat("data/pbmc3k_seurat_sce_loom.loom", from="loom", to="anndata", outFile="data/pbmc3k_seurat_sce_loom_anndata.h5ad")'
+            -e 'sceasy::convertFormat("data/pbmc3k_seurat_sce_loom.loom", from="loom", to="sce", outFile="data/pbmc3k_seurat_sce_loom_sce.rds", main_layer_name="scaled")'
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
       conda config --add channels bioconda;
       conda config --add channels conda-forge;
       conda create -q -y -n $TEST_ENV r-reticulate anndata loompy;
-      conda install -q -y -n $TEST_ENV bioconductor-singlecellexperiment bioconductor-loomexperiment r-seurat=4 r-monocle3;
+      conda install -q -y -n $TEST_ENV bioconductor-singlecellexperiment bioconductor-loomexperiment r-seurat=4 "r-deldir>=1.0.2" r-monocle3;
     fi;
 
 install:

--- a/R/functions.R
+++ b/R/functions.R
@@ -423,6 +423,7 @@ anndata2seurat <- function(inFile, outFile = NULL, main_layer = "counts", assay 
       message("X -> data")
     }
     names(assays) <- assay
+    Seurat::Key(assays[[assay]]) <- paste0(tolower(assay), "_")
 
     if (main_layer == "scale.data" && !is.null(raw_X)) {
       assays[[assay]]@meta.features <- raw_var_df


### PR DESCRIPTION
This PR fixes an issue in anndata2seurat() that produces object failed to load by Seurat v4.