### PR TITLE
Fix issue #56

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -439,7 +439,7 @@ anndata2seurat <- function(inFile, outFile = NULL, main_layer = "counts", assay 
     srt@meta.data <- obs_df
     embed_names <- unlist(reticulate::py_to_r(ad$obsm_keys()))
     if (length(embed_names) > 0) {
-      embeddings <- sapply(embed_names, function(x) reticulate::py_to_r(ad$obsm[x]), simplify = FALSE, USE.NAMES = TRUE)
+      embeddings <- sapply(embed_names, function(x) as.matrix(reticulate::py_to_r(ad$obsm[x])), simplify = FALSE, USE.NAMES = TRUE)
       names(embeddings) <- embed_names
       for (name in embed_names) {
         rownames(embeddings[[name]]) <- colnames(assays[[assay]])

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ BiocManager::install(c("LoomExperiment", "SingleCellExperiment"))
 
 To use sceasy ensure the anndata package (with scipy==1.2.1) is installed:
 
-```conda install anndata==0.6.19 scipy==1.2.1 -c bioconda```
+```conda install anndata scipy -c bioconda```
 
 Optionally, if you plan to convert between loom and anndata, please also ensure that the `loompy` package is installed:
 


### PR DESCRIPTION
There was an issue converting some files when a field is a dataframe instead of a matrix. I used as.matrix to automatically convert to a matrix. Also, I find that the most up-to-date versions of anndata and scipy work better, so I changed that in the README. 