### PR TITLE
Add `tolower` to format check

### DIFF
--- a/R/methods.R
+++ b/R/methods.R
@@ -13,8 +13,10 @@
 #' @return Output object
 convertFormat <- function(obj, from = c("anndata", "seurat", "sce", "loom"), to = c("anndata", "loom", "sce", "seurat", "cds"), outFile = NULL,
                           main_layer = NULL, ...) {
-  from <- match.arg(tolower(x = from))
-  to <- match.arg(tolower(x = to))
+  from <- tolower(x = from)
+  from <- match.arg(from)
+  to <- tolower(x = to)
+  to <- match.arg(to)
 
   tryCatch(
     {

--- a/R/methods.R
+++ b/R/methods.R
@@ -13,8 +13,8 @@
 #' @return Output object
 convertFormat <- function(obj, from = c("anndata", "seurat", "sce", "loom"), to = c("anndata", "loom", "sce", "seurat", "cds"), outFile = NULL,
                           main_layer = NULL, ...) {
-  from <- match.arg(from)
-  to <- match.arg(to)
+  from <- match.arg(tolower(x = from))
+  to <- match.arg(tolower(x = to))
 
   tryCatch(
     {


### PR DESCRIPTION
Hi sceasy team,

Just quick PR here to aid in format checking in the `convertFormat` function.  It just adds a `tolower` step when checking the object format.  That way capitalization doesn't throw error in running the function.

Best,
Sam