### PR TITLE
Updated the way var is read in from anndata2seurat to make it workable with old and new versions of seurat.

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -73,6 +73,7 @@ seurat2anndata <- function(obj, outFile = NULL, assay = "RNA", main_layer = "dat
     },
     drop_single_values = drop_single_values
   )
+  rownames(var) <- rownames(Seurat::GetAssay(obj, assay = assay)@features@.Data)
 
   obsm <- NULL
   reductions <- names(obj@reductions)

--- a/R/functions.R
+++ b/R/functions.R
@@ -63,7 +63,16 @@ seurat2anndata <- function(obj, outFile = NULL, assay = "RNA", main_layer = "dat
 
   obs <- .regularise_df(obj@meta.data, drop_single_values = drop_single_values)
 
-  var <- .regularise_df(Seurat::GetAssay(obj, assay = assay)@meta.features, drop_single_values = drop_single_values)
+  var <- .regularise_df(
+    if (slotExists(Seurat::GetAssay(obj, assay), "meta.features")) {
+      Seurat::GetAssay(obj, assay)@meta.features
+    } else if (slotExists(Seurat::GetAssay(obj, assay), "meta.data")) {
+      Seurat::GetAssay(obj, assay)@meta.data
+    } else {
+      stop("No meta.features or meta.data found on assay.")
+    },
+    drop_single_values = drop_single_values
+  )
 
   obsm <- NULL
   reductions <- names(obj@reductions)


### PR DESCRIPTION
I ran into a problem that occurs due to the naming scheme changes between older and newer versions of "var": meta.features / meta.data. I just added the following code to seurat2anndata

Someone else had this before (#82), and it seems like a quick fix that worked for me.

```r
var <- .regularise_df(
  if (slotExists(Seurat::GetAssay(obj, assay), "meta.features")) {
    Seurat::GetAssay(obj, assay)@meta.features
  } else if (slotExists(Seurat::GetAssay(obj, assay), "meta.data")) {
    Seurat::GetAssay(obj, assay)@meta.data
  } else {
    stop("No meta.features or meta.data found on assay.")
  },
  drop_single_values = drop_single_values
)
rownames(var) <- rownames(Seurat::GetAssay(obj, assay = assay)@features@.Data)
```